### PR TITLE
Update actions/checkout and actions/setup-python

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,10 @@ jobs:
       AWS_DEFAULT_REGION: us-west-2
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
           cache: "pip"


### PR DESCRIPTION
Clears out some deprecation warnings on our Github Actions - [#135](https://github.com/NASA-IMPACT/veda-backend/issues/135)