### PR TITLE
Fix a handful of ingestion API bugs

### DIFF
--- a/api/src/config.py
+++ b/api/src/config.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
     stac_url: AnyHttpUrl = Field(description="URL of STAC API")
 
     # See validate_dataset() in main.py
-    # raster_url: AnyHttpUrl = Field(description="URL of Raster API")
+    raster_url: AnyHttpUrl = Field(description="URL of Raster API")
 
     data_access_role: AwsArn = Field(
         description="ARN of AWS Role used to validate access to S3 data"

--- a/api/src/schemas.py
+++ b/api/src/schemas.py
@@ -239,7 +239,7 @@ class Dataset(BaseModel):
                 "If is_periodic is true, time_density must be one of"
                 "'month', 'day', or 'year'"
             )
-        if not values["is_periodic"] and values["time_density"] is not None:
+        if not values["is_periodic"] and values["time_density"] != 'null':
             raise ValueError("If is_periodic is false, time_density must be null")
         return values
 
@@ -264,7 +264,7 @@ class Dataset(BaseModel):
                 if (
                     item.discovery == "s3"
                     and re.search(item.filename_regex, fname.split("/")[-1])
-                    and fname.startswith(item.prefix)
+                    and '/'.join(fname.split("/")[3:]).startswith(item.prefix)
                 ):
                     if item.datetime_range:
                         try:


### PR DESCRIPTION
Couple of bugs made it into main - most of these were not deployed anywhere

- sample not defined in `/validate`
- regex inconsistency for s3 files - validation inconsistent with pipeline behaviour
- type error for dashboard variables - this brings things back in line with what we expect, but I'm not sure it's correct in the long run (`null` vs `"null"`)