### PR TITLE
Fix broken method name

### DIFF
--- a/api/src/main.py
+++ b/api/src/main.py
@@ -156,7 +156,7 @@ async def start_workflow_execution(
     """
     Triggers the ingestion workflow
     """
-    return helpers.trigger_airflow(input)
+    return helpers.trigger_discover(input)
 
 
 @app.get(


### PR DESCRIPTION
A method name used during testing of #34 was not properly updated after testing. This PR rectifies that oversight