### PR TITLE
Query airflow for multiple statuses and combine related run statuses

### DIFF
--- a/api/src/helpers.py
+++ b/api/src/helpers.py
@@ -84,7 +84,9 @@ def get_status(dag_run_id: str) -> Dict:
         },
         data=raw_data_ingest,
     )
-    decoded_response_ingest = base64.b64decode(mwaa_response_ingest.json()["stdout"]).decode("utf8")
+    decoded_response_ingest = base64.b64decode(
+        mwaa_response_ingest.json()["stdout"]
+    ).decode("utf8")
     rows_ingest = decoded_response_ingest.split("\n")
 
     raw_data_discover = "dags list-runs -d veda_discover"
@@ -96,7 +98,9 @@ def get_status(dag_run_id: str) -> Dict:
         },
         data=raw_data_discover,
     )
-    decoded_response_discover = base64.b64decode(mwaa_response_discover.json()["stdout"]).decode("utf8")
+    decoded_response_discover = base64.b64decode(
+        mwaa_response_discover.json()["stdout"]
+    ).decode("utf8")
     rows_discover = decoded_response_discover.split("\n")
 
     rows = rows_ingest + rows_discover

--- a/api/src/helpers.py
+++ b/api/src/helpers.py
@@ -24,7 +24,8 @@ def trigger_discover(input: Dict) -> Dict:
     )
 
     unique_key = str(uuid4())
-    raw_data = f"dags trigger veda_discover --conf '{input.json()}' -r {unique_key}"
+    run_id = f"{input.collection}_{unique_key}"
+    raw_data = f"dags trigger veda_discover --conf '{input.json()}' -r {run_id}"
     mwaa_response = requests.post(
         mwaa_webserver_hostname,
         headers={
@@ -40,10 +41,26 @@ def trigger_discover(input: Dict) -> Dict:
     else:
         return BaseResponse(
             **{
-                "id": unique_key,
+                "id": run_id,
                 "status": Status.started,
             }
         )
+
+
+def convert_status(status: str) -> Status:
+    """Converts airflow status strings to our status enum."""
+    if status == "success":
+        run_status = Status.succeeded
+    elif status == "failed":
+        run_status = Status.failed
+    elif status == "running":
+        run_status = Status.started
+    elif status == "queued":
+        run_status = Status.queued
+    else:
+        raise Exception(f"Unknown status: {status}")
+
+    return run_status
 
 
 def get_status(dag_run_id: str) -> Dict:
@@ -58,39 +75,46 @@ def get_status(dag_run_id: str) -> Dict:
         f"https://{mwaa_cli_token['WebServerHostname']}/aws_mwaa/cli"
     )
 
-    raw_data = "dags list-runs -d veda_discover"
-    mwaa_response = requests.post(
+    raw_data_ingest = "dags list-runs -d veda_ingest"
+    mwaa_response_ingest = requests.post(
         mwaa_webserver_hostname,
         headers={
             "Authorization": "Bearer " + mwaa_cli_token["CliToken"],
             "Content-Type": "application/json",
         },
-        data=raw_data,
+        data=raw_data_ingest,
     )
-    decoded_response = base64.b64decode(mwaa_response.json()["stdout"]).decode("utf8")
-    rows = decoded_response.split("\n")
+    decoded_response_ingest = base64.b64decode(mwaa_response_ingest.json()["stdout"]).decode("utf8")
+    rows_ingest = decoded_response_ingest.split("\n")
 
-    try:
-        matched_row = next(row for row in rows if dag_run_id in row)
-    except StopIteration:
-        raise Exception(f"Failed to find dag run id: {dag_run_id}")
+    raw_data_discover = "dags list-runs -d veda_discover"
+    mwaa_response_discover = requests.post(
+        mwaa_webserver_hostname,
+        headers={
+            "Authorization": "Bearer " + mwaa_cli_token["CliToken"],
+            "Content-Type": "application/json",
+        },
+        data=raw_data_discover,
+    )
+    decoded_response_discover = base64.b64decode(mwaa_response_discover.json()["stdout"]).decode("utf8")
+    rows_discover = decoded_response_discover.split("\n")
 
-    columns = matched_row.split("|")
-    status = columns[2].strip()
+    rows = rows_ingest + rows_discover
+    rows_columns = [row.split("|") for row in rows if dag_run_id in row]
+    statuses = [convert_status(row[2].strip()) for row in rows_columns]
 
-    # Statuses in Airflow differ slightly from our own, so we convert them here
-    if status == "success":
-        run_status = Status.succeeded
-    elif status == "failed":
-        run_status = Status.failed
-    elif status == "running":
-        run_status = Status.started
-    elif status == "queued":
-        run_status = Status.queued
+    if Status.failed in statuses:
+        total_status = Status.failed
+    elif Status.started in statuses:
+        total_status = Status.started
+    elif Status.queued in statuses:
+        total_status = Status.queued
+    else:
+        total_status = Status.succeeded
 
     return BaseResponse(
         **{
             "id": dag_run_id,
-            "status": run_status,
+            "status": total_status,
         }
     )


### PR DESCRIPTION
This PR updates the `get_status` function used when inspecting a discover/ingest run for status such that all statuses for a given discovery and downstream ingest dag runs are considered. Any failures reports a failure; any queued runs, a queued status; etc.