### PR TITLE
fix: deployment configs

### DIFF
--- a/cdk/config.py
+++ b/cdk/config.py
@@ -58,8 +58,8 @@ class Deployment(BaseSettings):
         description="URL of STAC API",
     )
 
-    jwks_url: AnyHttpUrl = Field(
-        description="URL of JWKS, e.g. https://cognito-idp.{region}.amazonaws.com/{userpool_id}/.well-known/jwks.json"  # noqa
+    raster_url: AnyHttpUrl = Field(
+        description="URL of Raster API"
     )
 
     data_access_role: AwsArn = Field(

--- a/cdk/config.py
+++ b/cdk/config.py
@@ -58,9 +58,7 @@ class Deployment(BaseSettings):
         description="URL of STAC API",
     )
 
-    raster_url: AnyHttpUrl = Field(
-        description="URL of Raster API"
-    )
+    raster_url: AnyHttpUrl = Field(description="URL of Raster API")
 
     data_access_role: AwsArn = Field(
         description="ARN of AWS Role used to validate access to S3 data"

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -52,6 +52,7 @@ class StacIngestionApi(Stack):
             "CLIENT_ID": config.client_id,
             "CLIENT_SECRET": config.client_secret,
             "MWAA_ENV": config.airflow_env,
+            "RASTER_URL": config.raster_url,
         }
         db_secret = self.get_db_secret(config.stac_db_secret_name, config.stage)
         db_vpc = ec2.Vpc.from_lookup(self, "vpc", vpc_id=config.stac_db_vpc_id)
@@ -163,7 +164,7 @@ class StacIngestionApi(Stack):
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PUBLIC
                 if db_subnet_public
-                else ec2.SubnetType.PRIVATE_ISOLATED
+                else ec2.SubnetType.PRIVATE_WITH_NAT
             ),
             allow_public_subnet=True,
             memory_size=2048,
@@ -229,7 +230,7 @@ class StacIngestionApi(Stack):
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PUBLIC
                 if db_subnet_public
-                else ec2.SubnetType.PRIVATE_ISOLATED
+                else ec2.SubnetType.PRIVATE_WITH_NAT
             ),
             allow_public_subnet=True,
             memory_size=2048,


### PR DESCRIPTION
- jwks_url in config.py wasn't being used, jwks_url still being set by build_jwks_url in stack.py
- RASTER_URL is a required src config but wasn't being pulled from .env, added to cdk config.py/stack.py
- PRIVATE_WITH_NAT is the type present in the generated VPC