### PR TITLE
Shrink lambdas using docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ This codebase utilizes the [Pydantic SSM Settings](https://github.com/developmen
    source .venv/bin/activate
    ```
 
-1. Install dependencies:
+2. Install dependencies:
 
    ```
    pip install -r api/requirements.txt
    ```
 
-1. Run API:
+3. Run API:
 
    ```
-   uvicorn api.src.main:app --reload
+   python api/local.py
    ```
 
    _Note:_ If no `.env` file is present, the API will connect to resources in the `dev` deployment via [pydantic-ssm-settings](https://github.com/developmentseed/pydantic-ssm-settings). This requires that your `AWS_PROFILE` be set to the profile associated with the AWS account hosting the `dev` deployment.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,20 @@
+FROM lambci/lambda:build-python3.8
+
+WORKDIR /tmp
+
+COPY api /tmp/ingestor
+RUN pip install -r /tmp/ingestor/requirements.txt -t /asset --no-binary pydantic 
+RUN rm -rf /tmp/ingestor
+# TODO this is temporary until we use a real packaging system like setup.py or poetry
+COPY api/src /asset
+
+# # Reduce package size and remove useless files
+RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;
+RUN cd /asset && find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
+RUN cd /asset && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
+RUN find /asset -type d -a -name 'tests' -print0 | xargs -0 rm -rf
+RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/geos_license /asset/Misc
+
+COPY api/src/handler.py /asset/handler.py
+
+CMD ["echo", "hello world"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-python3.8
+FROM public.ecr.aws/sam/build-python3.9:latest
 
 WORKDIR /tmp
 
@@ -11,7 +11,7 @@ COPY api/src /asset
 # # Reduce package size and remove useless files
 RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;
 RUN cd /asset && find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
-RUN cd /asset && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
+#RUN cd /asset && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
 RUN find /asset -type d -a -name 'tests' -print0 | xargs -0 rm -rf
 RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/geos_license /asset/Misc
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,10 +3,10 @@ FROM public.ecr.aws/sam/build-python3.9:latest
 WORKDIR /tmp
 
 COPY api /tmp/ingestor
-RUN pip install -r /tmp/ingestor/requirements.txt -t /asset --no-binary pydantic 
+RUN pip install -r /tmp/ingestor/requirements.txt -t /asset --no-binary pydantic uvicorn
 RUN rm -rf /tmp/ingestor
 # TODO this is temporary until we use a real packaging system like setup.py or poetry
-COPY api/src /asset
+COPY api/src /asset/src
 
 # # Reduce package size and remove useless files
 RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;
@@ -15,6 +15,6 @@ RUN cd /asset && find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
 RUN find /asset -type d -a -name 'tests' -print0 | xargs -0 rm -rf
 RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/geos_license /asset/Misc
 
-COPY api/src/handler.py /asset/handler.py
+COPY api/handler.py /asset/handler.py
 
 CMD ["echo", "hello world"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -16,5 +16,6 @@ RUN find /asset -type d -a -name 'tests' -print0 | xargs -0 rm -rf
 RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/geos_license /asset/Misc
 
 COPY api/handler.py /asset/handler.py
+COPY api/ingestor.py /asset/ingestor.py
 
 CMD ["echo", "hello world"]

--- a/api/handler.py
+++ b/api/handler.py
@@ -2,7 +2,7 @@
 Entrypoint for Lambda execution.
 """
 
-from main import app
 from mangum import Mangum
+from src.main import app
 
 handler = Mangum(app, lifespan="off")

--- a/api/ingestor.py
+++ b/api/ingestor.py
@@ -1,0 +1,7 @@
+"""
+Entrypoint for Lambda execution.
+"""
+
+import src.ingestor as ingestor
+
+handler = ingestor.handler

--- a/api/local.py
+++ b/api/local.py
@@ -1,0 +1,7 @@
+""" Script used to run the API locally"""
+
+import uvicorn
+from src import main
+
+if __name__ == "__main__":
+    uvicorn.run(main.app, host="0.0.0.0", port=8000)

--- a/api/src/auth.py
+++ b/api/src/auth.py
@@ -5,12 +5,11 @@ import logging
 from typing import Dict
 
 import boto3
+import config
 import requests
 from authlib.jose import JsonWebKey, JsonWebToken, JWTClaims, KeySet, errors
 from cachetools import TTLCache, cached
 from fastapi import Depends, HTTPException, security
-
-from . import config
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +17,7 @@ token_scheme = security.HTTPBearer()
 
 
 def get_settings() -> config.Settings:
-    from . import main
+    import main
 
     return main.settings
 

--- a/api/src/auth.py
+++ b/api/src/auth.py
@@ -5,8 +5,8 @@ import logging
 from typing import Dict
 
 import boto3
-import config
 import requests
+import src.config as config
 from authlib.jose import JsonWebKey, JsonWebToken, JWTClaims, KeySet, errors
 from cachetools import TTLCache, cached
 from fastapi import Depends, HTTPException, security
@@ -17,7 +17,7 @@ token_scheme = security.HTTPBearer()
 
 
 def get_settings() -> config.Settings:
-    import main
+    import src.main as main
 
     return main.settings
 

--- a/api/src/collection.py
+++ b/api/src/collection.py
@@ -1,29 +1,25 @@
 import os
-
 from typing import Union
 
 import fsspec
-import xstac
-
 import xarray as xr
-
+import xstac
 from pypgstac.db import PgstacDB
-
-from .schemas import (
+from schemas import (
     COGDataset,
     DashboardCollection,
+    DataType,
     SpatioTemporalExtent,
     ZarrDataset,
-    DataType,
 )
-from .utils import (
+from utils import (
     IngestionType,
     convert_decimals_to_float,
     get_db_credentials,
     load_into_pgstac,
 )
-from .validators import get_s3_credentials
-from .vedaloader import VEDALoader
+from validators import get_s3_credentials
+from vedaloader import VEDALoader
 
 
 class Publisher:

--- a/api/src/collection.py
+++ b/api/src/collection.py
@@ -5,21 +5,21 @@ import fsspec
 import xarray as xr
 import xstac
 from pypgstac.db import PgstacDB
-from schemas import (
+from src.schemas import (
     COGDataset,
     DashboardCollection,
     DataType,
     SpatioTemporalExtent,
     ZarrDataset,
 )
-from utils import (
+from src.utils import (
     IngestionType,
     convert_decimals_to_float,
     get_db_credentials,
     load_into_pgstac,
 )
-from validators import get_s3_credentials
-from vedaloader import VEDALoader
+from src.validators import get_s3_credentials
+from src.vedaloader import VEDALoader
 
 
 class Publisher:

--- a/api/src/dependencies.py
+++ b/api/src/dependencies.py
@@ -1,9 +1,10 @@
 import logging
 
+import auth
 import boto3
+import config
+import services
 from fastapi import Depends, HTTPException, security
-
-from . import auth, config, services
 
 logger = logging.getLogger(__name__)
 

--- a/api/src/dependencies.py
+++ b/api/src/dependencies.py
@@ -1,9 +1,9 @@
 import logging
 
-import auth
 import boto3
-import config
-import services
+import src.auth as auth
+import src.config as config
+import src.services as services
 from fastapi import Depends, HTTPException, security
 
 logger = logging.getLogger(__name__)

--- a/api/src/handler.py
+++ b/api/src/handler.py
@@ -2,8 +2,7 @@
 Entrypoint for Lambda execution.
 """
 
+from main import app
 from mangum import Mangum
-
-from .main import app
 
 handler = Mangum(app, lifespan="off")

--- a/api/src/helpers.py
+++ b/api/src/helpers.py
@@ -8,7 +8,7 @@ import requests
 from fastapi import HTTPException
 
 try:
-    from .schemas import BaseResponse, Status
+    from schemas import BaseResponse, Status
 except ImportError:
     from schemas import BaseResponse, Status
 

--- a/api/src/helpers.py
+++ b/api/src/helpers.py
@@ -8,9 +8,9 @@ import requests
 from fastapi import HTTPException
 
 try:
-    from schemas import BaseResponse, Status
+    from src.schemas import BaseResponse, Status
 except ImportError:
-    from schemas import BaseResponse, Status
+    from src.schemas import BaseResponse, Status
 
 
 def trigger_discover(input: Dict) -> Dict:

--- a/api/src/ingestor.py
+++ b/api/src/ingestor.py
@@ -6,12 +6,12 @@ from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence
 
 import boto3
 import ddbcereal
-from auth import get_settings
 from boto3.dynamodb.types import TypeDeserializer
-from dependencies import get_table
 from pypgstac.db import PgstacDB
-from schemas import Ingestion, Status
-from utils import (
+from src.auth import get_settings
+from src.dependencies import get_table
+from src.schemas import Ingestion, Status
+from src.utils import (
     IngestionType,
     convert_decimals_to_float,
     get_db_credentials,

--- a/api/src/ingestor.py
+++ b/api/src/ingestor.py
@@ -6,13 +6,12 @@ from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence
 
 import boto3
 import ddbcereal
+from auth import get_settings
 from boto3.dynamodb.types import TypeDeserializer
+from dependencies import get_table
 from pypgstac.db import PgstacDB
-
-from .auth import get_settings
-from .dependencies import get_table
-from .schemas import Ingestion, Status
-from .utils import (
+from schemas import Ingestion, Status
+from utils import (
     IngestionType,
     convert_decimals_to_float,
     get_db_credentials,

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -2,22 +2,19 @@ import os
 from getpass import getuser
 from typing import Dict, Union
 
+import auth
+import collection as collection_loader
+import config
+import dependencies
+import helpers
 import requests
+import schemas
+import services
+from doc import DESCRIPTION
 from fastapi import Body, Depends, FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordRequestForm
-
-from .doc import DESCRIPTION
-from . import (
-    auth,
-    collection as collection_loader,
-    config,
-    dependencies,
-    helpers,
-    schemas,
-    services,
-)
 
 settings = (
     config.Settings()

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -2,19 +2,19 @@ import os
 from getpass import getuser
 from typing import Dict, Union
 
-import auth
-import collection as collection_loader
-import config
-import dependencies
-import helpers
 import requests
-import schemas
-import services
-from doc import DESCRIPTION
+import src.auth as auth
+import src.collection as collection_loader
+import src.config as config
+import src.dependencies as dependencies
+import src.helpers as helpers
+import src.schemas as schemas
+import src.services as services
 from fastapi import Body, Depends, FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordRequestForm
+from src.doc import DESCRIPTION
 
 settings = (
     config.Settings()

--- a/api/src/schemas.py
+++ b/api/src/schemas.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
 from urllib.parse import urlparse
 
+import validators
 from fastapi.exceptions import RequestValidationError
 from pydantic import (
     BaseModel,
@@ -17,15 +18,13 @@ from pydantic import (
     root_validator,
     validator,
 )
+from schema_helpers import BboxExtent, SpatioTemporalExtent, TemporalExtent
 from stac_pydantic import Collection, Item, shared
 from stac_pydantic.links import Link
 from typing_extensions import Annotated
 
-from . import validators
-from .schema_helpers import BboxExtent, SpatioTemporalExtent, TemporalExtent
-
 if TYPE_CHECKING:
-    from . import services
+    import services
 
 
 class AccessibleAsset(shared.Asset):

--- a/api/src/schemas.py
+++ b/api/src/schemas.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
 from urllib.parse import urlparse
 
-import validators
+import src.validators as validators
 from fastapi.exceptions import RequestValidationError
 from pydantic import (
     BaseModel,
@@ -18,13 +18,13 @@ from pydantic import (
     root_validator,
     validator,
 )
-from schema_helpers import BboxExtent, SpatioTemporalExtent, TemporalExtent
+from src.schema_helpers import BboxExtent, SpatioTemporalExtent, TemporalExtent
 from stac_pydantic import Collection, Item, shared
 from stac_pydantic.links import Link
 from typing_extensions import Annotated
 
 if TYPE_CHECKING:
-    import services
+    from src import services
 
 
 class AccessibleAsset(shared.Asset):

--- a/api/src/services.py
+++ b/api/src/services.py
@@ -1,7 +1,7 @@
 import decimal
 from typing import TYPE_CHECKING, List
 
-import schemas
+import src.schemas as schemas
 from boto3.dynamodb import conditions
 from boto3.dynamodb.types import DYNAMODB_CONTEXT
 from pydantic import parse_obj_as

--- a/api/src/services.py
+++ b/api/src/services.py
@@ -1,11 +1,10 @@
 import decimal
 from typing import TYPE_CHECKING, List
 
+import schemas
 from boto3.dynamodb import conditions
 from boto3.dynamodb.types import DYNAMODB_CONTEXT
 from pydantic import parse_obj_as
-
-from . import schemas
 
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb.service_resource import Table

--- a/api/src/utils.py
+++ b/api/src/utils.py
@@ -8,9 +8,8 @@ import orjson
 import pydantic
 from pypgstac.db import PgstacDB
 from pypgstac.load import Methods
-
-from .schemas import AccessibleItem, DashboardCollection
-from .vedaloader import VEDALoader
+from schemas import AccessibleItem, DashboardCollection
+from vedaloader import VEDALoader
 
 
 class IngestionType(str, Enum):

--- a/api/src/utils.py
+++ b/api/src/utils.py
@@ -8,8 +8,8 @@ import orjson
 import pydantic
 from pypgstac.db import PgstacDB
 from pypgstac.load import Methods
-from schemas import AccessibleItem, DashboardCollection
-from vedaloader import VEDALoader
+from src.schemas import AccessibleItem, DashboardCollection
+from src.vedaloader import VEDALoader
 
 
 class IngestionType(str, Enum):

--- a/api/src/validators.py
+++ b/api/src/validators.py
@@ -10,7 +10,7 @@ from dateutil.relativedelta import relativedelta
 
 @functools.lru_cache
 def get_s3_credentials():
-    from .main import settings
+    from main import settings
 
     print("Fetching S3 Credentials...")
 
@@ -103,7 +103,7 @@ def collection_exists(collection_id: str) -> bool:
     """
     Ensure collection exists in STAC
     """
-    from .main import settings
+    from main import settings
 
     url = "/".join(
         f'{url.strip("/")}' for url in [settings.stac_url, "collections", collection_id]

--- a/api/src/validators.py
+++ b/api/src/validators.py
@@ -10,7 +10,7 @@ from dateutil.relativedelta import relativedelta
 
 @functools.lru_cache
 def get_s3_credentials():
-    from main import settings
+    from src.main import settings
 
     print("Fetching S3 Credentials...")
 
@@ -103,7 +103,7 @@ def collection_exists(collection_id: str) -> bool:
     """
     Ensure collection exists in STAC
     """
-    from main import settings
+    from src.main import settings
 
     url = "/".join(
         f'{url.strip("/")}' for url in [settings.stac_url, "collections", collection_id]

--- a/cdk/config.py
+++ b/cdk/config.py
@@ -79,15 +79,6 @@ class Deployment(BaseSettings):
         description="ID of AWS ECR repository used for OIDC provider",
     )
 
-    oidc_provider_arn: Optional[AwsOidcArn] = Field(
-        description="ARN of AWS OIDC provider used for authentication"
-    )
-
-    oidc_repo_id: str = Field(
-        "NASA-IMPACT/veda-stac-ingestor",
-        description="ID of AWS ECR repository used for OIDC provider",
-    )
-
     class Config:
         env_prefix = ""
         case_sentive = False

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -71,7 +71,12 @@ class StacIngestionApi(Stack):
             "RASTER_URL": config.raster_url,
             "OIDC_PROVIDER_ARN": config.oidc_provider_arn,
             "OIDC_PROVIDER_REPO_ID": config.oidc_repo_id,
+            "STAC_DB_SECRET_NAME": config.stac_db_secret_name,
+            "STAC_DB_VPC_ID": config.stac_db_vpc_id,
+            "STAC_DB_SECURITY_GROUP_ID": config.stac_db_security_group_id,
+            "STAC_DB_PUBLIC_SUBNET": config.stac_db_public_subnet,
         }
+
         db_secret = self.get_db_secret(config.stac_db_secret_name, config.stage)
         db_vpc = ec2.Vpc.from_lookup(self, "vpc", vpc_id=config.stac_db_vpc_id)
         db_security_group = ec2.SecurityGroup.from_security_group_id(

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ python-dotenv
 python-multipart
 pytest-mock
 pre-commit
+uvicorn


### PR DESCRIPTION
Lambdas were not deployable due to their package size (numpy and pandas are needed for zarr ingests). This PR refactors our lambdas to use Docker instead. I had to reorganize imports, as well as adjust tests and local dev instructions to align with the new structure.