### PR TITLE
Upgrade pypgstac to 0.7.4

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,6 @@
 # Waiting for https://github.com/stac-utils/stac-pydantic/pull/116 and 117
 Authlib==1.0.1
-cachetools==5.1.0
+cachetools==5.3.*
 ddbcereal==2.1.1
 fastapi>=0.75.1
 fsspec==2023.3.0
@@ -9,7 +9,7 @@ orjson>=3.6.8
 psycopg[binary,pool]>=3.0.15
 pydantic_ssm_settings>=0.2.0
 pydantic>=1.9.0
-pypgstac==0.6.13
+pypgstac==0.7.4
 python-multipart==0.0.5
 requests>=2.27.1
 s3fs==2023.3.0


### PR DESCRIPTION
This PR coincides with the pgstac upgrade for veda-backend: https://github.com/NASA-IMPACT/veda-backend/pull/180