### PR TITLE
Pin pypgstac to 0.6.6

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -9,7 +9,7 @@ orjson>=3.6.8
 psycopg[binary,pool]>=3.0.15
 pydantic_ssm_settings>=0.2.0
 pydantic>=1.9.0
-pypgstac==0.6.13
+pypgstac==0.6.6
 python-multipart==0.0.5
 requests>=2.27.1
 s3fs==2023.3.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -14,6 +14,7 @@ python-multipart==0.0.5
 requests>=2.27.1
 s3fs==2023.3.0
 stac-pydantic @ git+https://github.com/ividito/stac-pydantic.git@3f4cb381c85749bb4b15d1181179057ec0f51a94
+typing-extensions==4.5.0
 xarray==2023.1.0
 xstac==1.1.0
 zarr==2.13.6

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,7 +5,7 @@ ddbcereal==2.1.1
 fastapi>=0.75.1
 fsspec==2023.3.0
 mangum>=0.15.0
-orjson>=3.6.8
+orjson>=3.9.0
 psycopg[binary,pool]>=3.0.15
 pydantic_ssm_settings>=0.2.0
 pydantic>=1.9.0


### PR DESCRIPTION
We're seeing 500s from collection ingest due to a version mismatch w/ the database (i.e. `Exception: pypgstac version 0.6.13 is not compatible with the target database version 0.6.6`)