### PR TITLE
Upgrade pypgstac

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,8 +8,8 @@ mangum>=0.15.0
 orjson>=3.9.0
 psycopg[binary,pool]>=3.0.15
 pydantic_ssm_settings>=0.2.0
-pydantic>=1.9.0
-pypgstac==0.7.4
+pydantic>=1.9.0,<2
+pypgstac==0.7.10
 python-multipart==0.0.5
 requests>=2.27.1
 s3fs==2023.3.0


### PR DESCRIPTION
# What
Catch up to latest pgstac version in veda-backend and temporarily pin pydantic to previous release while sorting out pytdantic 2 breaking changes.

# Related
https://github.com/NASA-IMPACT/veda-backend/pull/178