### PR TITLE
Relax collection ID validation, correct datetime validations.

### DIFF
--- a/api/src/schema_helpers.py
+++ b/api/src/schema_helpers.py
@@ -49,7 +49,7 @@ class TemporalExtent(BaseModel):
     startdate: datetime
     enddate: datetime
 
-    @root_validator
+    @root_validator(pre=True)
     def check_dates(cls, v):
         if v["startdate"] >= v["enddate"]:
             raise ValueError("Invalid extent - startdate must be before enddate")


### PR DESCRIPTION
Fixes for #67 and #75 

- Datetimes that do not exist are not checked for valid ranges
- Collection ids that already exist are allowed to break rules