### PR TITLE
Fix/collection summaries and extents

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,6 +1,11 @@
 name: CICD
 
 on:
+  push:
+    branches:
+      - 'main'
+      - 'dev'
+      - 'production'
   pull_request:
     types: [ opened, reopened, edited, synchronize ]
 

--- a/api/src/vedaloader.py
+++ b/api/src/vedaloader.py
@@ -30,18 +30,7 @@ class VEDALoader(Loader):
                 logger.info(f"Updating extents for collection: {collection_id}.")
                 cur.execute(
                     """
-                    UPDATE collections SET
-                    content = content ||
-                    jsonb_build_object(
-                        'extent', jsonb_build_object(
-                            'spatial', jsonb_build_object(
-                                'bbox', collection_bbox(collections.id)
-                            ),
-                            'temporal', jsonb_build_object(
-                                'interval', collection_temporal_extent(collections.id)
-                            )
-                        )
-                    )
+                    UPDATE collections set content = content || pgstac.collection_extent(collections.id)
                     WHERE collections.id=%s;
                     """,
                     (collection_id,),


### PR DESCRIPTION
## What
Use inbuilt pgstac utility function `pgstac.collection_extent(collection_id text)` to apply the maximum date range from the items partitions instead of the outdated `collection_temporal_extent` utility that uses only the nominal item datetime.

## How tested
I executed and verified this method in a test database deployed for this [backend pr](https://github.com/NASA-IMPACT/veda-backend/pull/211). I'm still trying to think of ways to test the actual changes in the ingestor but the updating dev deployment and running an actual ingest may be the easiest way to go.
```sql
UPDATE collections set content = content || pgstac.collection_extent(collections.id)
WHERE collections.id = :_collection;
```
https://github.com/NASA-IMPACT/veda-backend/pull/211