### PR TITLE
fix: subnet type changed to match shared VPC

### DIFF
--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -264,7 +264,7 @@ class StacIngestionApi(Stack):
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PUBLIC
                 if db_subnet_public
-                else ec2.SubnetType.PRIVATE_ISOLATED
+                else ec2.SubnetType.PRIVATE_WITH_EGRESS
             ),
             allow_public_subnet=True,
             memory_size=2048,
@@ -330,7 +330,7 @@ class StacIngestionApi(Stack):
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PUBLIC
                 if db_subnet_public
-                else ec2.SubnetType.PRIVATE_ISOLATED
+                else ec2.SubnetType.PRIVATE_WITH_EGRESS
             ),
             allow_public_subnet=True,
             memory_size=2048,


### PR DESCRIPTION
Fixes #85 

Had a hard time getting this to synthesize locally, but I've confirmed that this is the right setting using the following script:

```
# Use dev VPC (works with any VPC)
VPC_ID=vpc-0512162c42da5e645

# Get all subnets in the VPC
subnets=$(aws ec2 describe-subnets --filters "Name=vpc-id,Values=$VPC_ID" --query "Subnets[*].SubnetId" --output text)

for subnet in $subnets; do
    # Check the route tables associated with the subnet
    routes=$(aws ec2 describe-route-tables --filters "Name=association.subnet-id,Values=$subnet" --query "RouteTables[*].Routes")

    if [[ $routes == *"igw-"* ]]; then
        echo "$subnet is a public subnet"
    elif [[ $routes == *"nat-"* ]]; then
        echo "$subnet is a PRIVATE_WITH_EGRESS subnet"
    else
        echo "$subnet is a PRIVATE_ISOLATED subnet"
    fi
done
```